### PR TITLE
Update eslint plugin ava

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "ava": "^0.15.0",
+    "ava": "^0.15.1",
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-2": "^6.5.0",
     "eslint": "^2.10.2",
     "eslint-config-google": "^0.5.0",
-    "eslint-plugin-ava": "^2.3.1",
+    "eslint-plugin-ava": "^2.4.0",
     "remark": "^4.2.2",
     "remark-lint": "^3.2.1"
   },

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,6 +1,3 @@
 extends: plugin:ava/recommended
 plugins:
   - ava
-# TODO disable when macro issue is resolved
-rules:
-  ava/test-title: warn

--- a/test/index.js
+++ b/test/index.js
@@ -4,26 +4,33 @@ import es2015 from 'babel-preset-es2015';
 import stage2 from 'babel-preset-stage-2';
 import plugin from '../dist/index';
 
-function babelES5Transform(t, input, expected) {
-  const actual = transform(input, {plugins: [plugin]}).code;
-  t.is(actual, expected);
+/**
+ * Creates test macros from babel presets and a test prefix
+ * @param {Object[]} presets - babel presets for transform
+ * @param {string} prefix - text to prepend to expected output
+ * @return {function} test macro
+ */
+function babelTransformFactory(presets = [], prefix = '') {
+  return (t, input, expected) => {
+    const actual = transform(input, {plugins: [plugin], presets}).code;
+    t.is(actual, `${prefix}${expected}`);
+  };
 }
 
-function babelES6Transform(t, input, expected) {
-  const actual = transform(input, {plugins: [plugin], presets: [es2015]}).code;
-  t.is(actual, '"use strict";\n\n' + expected);
-}
-
-function babelES7Transform(t, input, expected) {
-  const actual = transform(input, {plugins: [plugin], presets: [es2015, stage2]}).code;
-  t.is(actual, '"use strict";\n\n' + expected);
-}
-
+/**
+ * Creates titles for a test macro
+ * @param {string} version - Javascript version or dialet being tested
+ * @return {function} title macro
+ */
 function titleFactory(version) {
   return (providedTitle, input, expected) => providedTitle ?
     `${providedTitle} in ${version}` :
     `"${input}" becomes "${expected}" in ${version}`;
 }
+
+const babelES5Transform = babelTransformFactory();
+const babelES6Transform = babelTransformFactory([es2015], '"use strict";\n\n');
+const babelES7Transform = babelTransformFactory([es2015, stage2], '"use strict";\n\n');
 
 babelES5Transform.title = titleFactory('ES5');
 babelES6Transform.title = titleFactory('ES6');


### PR DESCRIPTION
update eslint plugin ava
remove temporary fix
adds a factory for creating test macros and title macros
adds doc comments for new factory functions
